### PR TITLE
*sigh* we need python at runtime for dynamic libraries.

### DIFF
--- a/build/plan.sh
+++ b/build/plan.sh
@@ -5,8 +5,8 @@ pkg_origin=tmclaugh
 pkg_maintainer='Tom McLaughlin'
 pkg_license=('MIT')
 pkg_upstream_url='https://github.com/threatstack/threatstack-to-s3'
-pkg_build_deps=(core/python2 core/virtualenv)
-pkg_deps=(core/coreutils)
+pkg_build_deps=(core/virtualenv)
+pkg_deps=(core/coreutils core/python2)
 pkg_exports=([http]=8080)
 pkg_expose=(http)
 


### PR DESCRIPTION
We need to have Python's dynamic libraries installed.